### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,12 @@ project(SurfaceModelNodesSelector)
 
 #-----------------------------------------------------------------------------
 # Extension meta-information
-set(EXTENSION_HOMEPAGE "https://github.com/saimasafdar2021/Slicer_SurfaceModelNodesSelector")
-set(EXTENSION_CATEGORY "SurfaceModelNodesSelector")
+set(EXTENSION_HOMEPAGE "https://github.com/saimasafdar2021/Slicer_SurfaceModelNodesSelector#readme")
+set(EXTENSION_CATEGORY "Surface Models")
 set(EXTENSION_CONTRIBUTORS "Saima Safdar (UWA)")
-set(EXTENSION_DESCRIPTION "This extensions selects the nodes/indexes of any surface model automatically. ")
-set(EXTENSION_ICONURL "https://github.com/saimasafdar2021/Slicer_SurfaceModelNodesSelector/blob/main/sModel.png")
-set(EXTENSION_SCREENSHOTURLS "https://github.com/saimasafdar2021/Slicer_SurfaceModelNodesSelector/blob/main/sModel.png")
+set(EXTENSION_DESCRIPTION "The module selects the nodes/vertices of each triangle in a surface modle and place a fiducial (3D point) at each vertex of each triangle in a surface model. The surface model can be any model.")
+set(EXTENSION_ICONURL "https://raw.githubusercontent.com/saimasafdar2021/Slicer_SurfaceModelNodesSelector/main/SurfaceModelNodesSelector.png")
+set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/saimasafdar2021/Slicer_SurfaceModelNodesSelector/main/sModel.png")
 set(EXTENSION_DEPENDS "NA") # Specified as a list or "NA" if no dependencies
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized in the ExtensionsIndex repository.

Related pull requests:
* https://github.com/Slicer/ExtensionsIndex/pull/2004